### PR TITLE
Remove confusing secondary buck.pex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 
 # BUCK=buck # System version
 BUCK=./buck.pex # Custom version
-# BUCK=tools/buck.pex # Custom version
 
 log:
 	echo "Make"


### PR DESCRIPTION
We have two custom versions of Buck: `./buck.pex` and `tools/buck.pex`. Since there is no documentation around either (i.e. what version of Buck is it), there is no way to know which one I should use. To make things less confusing for someone consuming this repo, I propose we remove the custom version that we are not currently using.

cc: @shepting 