### PR TITLE
Introduce suppress_warnings flag

### DIFF
--- a/Config/buck_rule_macros.bzl
+++ b/Config/buck_rule_macros.bzl
@@ -4,6 +4,7 @@ load("//Config:configs.bzl", "binary_configs", "library_configs", "pod_library_c
 def apple_pod_lib(**kwargs):
     apple_lib(
         warning_as_error = False,
+        suppress_warnings = True,
         **kwargs
     )
 
@@ -31,6 +32,7 @@ def apple_lib(
         compiler_flags = None,
         swift_compiler_flags = None,
         warning_as_error = True,
+        suppress_warnings = False,
         **kwargs):
     compiler_flags = compiler_flags or []
     swift_compiler_flags = swift_compiler_flags or []
@@ -42,7 +44,7 @@ def apple_lib(
     if warning_as_error:
         compiler_flags.append("-Werror")
         swift_compiler_flags.append("-warnings-as-errors")
-    else:
+    elif suppress_warnings:
         compiler_flags.append("-w")
         swift_compiler_flags.append("-suppress-warnings")
 

--- a/Config/buck_rule_macros.bzl
+++ b/Config/buck_rule_macros.bzl
@@ -1,7 +1,7 @@
 load("//Config:configs.bzl", "binary_configs", "library_configs", "pod_library_configs")
 
 # This is just a regular lib that was warnings not set to error
-def apple_pod_lib(**kwargs):
+def apple_third_party_lib(**kwargs):
     apple_lib(
         warning_as_error = False,
         suppress_warnings = True,

--- a/Pods/BUCK
+++ b/Pods/BUCK
@@ -1,13 +1,13 @@
-load("//Config:buck_rule_macros.bzl", "apple_lib", "apple_pod_lib")
+load("//Config:buck_rule_macros.bzl", "apple_lib", "apple_third_party_lib")
 
-apple_pod_lib(
+apple_third_party_lib(
     name = "CryptoSwift",
     srcs = glob([
         "CryptoSwift/**/*.swift",
     ]),
 )
 
-apple_pod_lib(
+apple_third_party_lib(
     name = "OHHTTPStubs",
     exported_headers = glob([
         "OHHTTPStubs/**/*.h",


### PR DESCRIPTION
`warning_as_error` is a bit too binary. This new `suppress_warnings` allows us to opt individual modules into allowing warnings without suppressing them.