### PR TITLE
Specify SWIFT_VERSION as 4.0 instead of 4

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -34,7 +34,7 @@ apple_binary(
         "//App/...",
     ],
     configs = binary_configs("ExampleApp"),
-    swift_version = "4",
+    swift_version = "4.0",
     srcs = [
         "ViewController.swift",
         "AppDelegate.swift",

--- a/Config/buck_rule_macros.bzl
+++ b/Config/buck_rule_macros.bzl
@@ -89,7 +89,7 @@ def apple_test_all(
 def apple_lib(
         name,
         visibility = ["PUBLIC"],
-        swift_version = "4",
+        swift_version = "4.0",
         modular = True,
         compiler_flags = None,
         swift_compiler_flags = None,


### PR DESCRIPTION
When `SWIFT_VERSION` is set to `4` rather than `4.0`, `mlmodel`'s fail to compile.