### PR TITLE
Set "SKIP_INSTALL" to "YES" for library projects.

### DIFF
--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -30,11 +30,16 @@ def bundle_identifier(name):
 def library_configs():
     lib_specific_config = {
         "SWIFT_WHOLE_MODULE_OPTIMIZATION": "YES",
+
+        # Setting SKIP_INSTALL to NO for library configs would create
+        # create a generic xcode archive which can not be uploaded the app store
+        "SKIP_INSTALL": "YES",
     }
     library_config = SHARED_CONFIGS + lib_specific_config
     configs = {
         "Debug": library_config,
         "Profile": library_config,
+        "Release": lib_specific_config,
     }
     return configs
 

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -31,7 +31,7 @@ def library_configs():
     lib_specific_config = {
         "SWIFT_WHOLE_MODULE_OPTIMIZATION": "YES",
 
-        # Setting SKIP_INSTALL to NO for library configs would create
+        # Setting SKIP_INSTALL to NO for static library configs would create
         # create a generic xcode archive which can not be uploaded the app store
         # https://developer.apple.com/library/archive/technotes/tn2215/_index.html
         "SKIP_INSTALL": "YES",

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -33,6 +33,7 @@ def library_configs():
 
         # Setting SKIP_INSTALL to NO for library configs would create
         # create a generic xcode archive which can not be uploaded the app store
+        # https://developer.apple.com/library/archive/technotes/tn2215/_index.html
         "SKIP_INSTALL": "YES",
     }
     library_config = SHARED_CONFIGS + lib_specific_config


### PR DESCRIPTION
Set SKIP_INSTALL to YES for all library projects created through buck except for app targets. Before this change attempting to archive the app would create a generic xcode archive which could not be uploaded to the app store. This config change fixes it (got the solution from this [SO post](https://stackoverflow.com/questions/10715211/cannot-generate-ios-app-archive-in-xcode))

Tested by checking that the lib project Skip Install values are set to Yes after project generation.

@dfed @bachand @fdiaz 