### PR TITLE
[WIP] Add example of Apple Watch app

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -100,7 +100,7 @@ apple_bundle(
     info_plist = "Info.plist",
     info_plist_substitutions = info_plist_substitutions("ExampleApp"),
     deps = [
-        "//Watch::DemoWatchApp#watch",
+        "//Watch:DemoWatchApp#watch",
     ]
 )
 

--- a/App/BUCK
+++ b/App/BUCK
@@ -99,6 +99,9 @@ apple_bundle(
     product_name = "ExampleApp",
     info_plist = "Info.plist",
     info_plist_substitutions = info_plist_substitutions("ExampleApp"),
+    deps = [
+        "//Watch::DemoWatchApp#watch",
+    ]
 )
 
 apple_package(

--- a/Watch/BUCK
+++ b/Watch/BUCK
@@ -1,9 +1,21 @@
+config = {
+    "SDKROOT": "watchos",
+    "WATCHOS_DEPLOYMENT_TARGET": "4.0",
+}
+
+configs = {
+    "Debug": config,
+    "Profile": config,
+    "Release": config,
+}
+
 apple_binary(
     name = "DemoWatchAppExtensionBinary",
     srcs = glob([
         "WatchExtension/**/*.m",
     ]),
     compiler_flags = ["-fobjc-arc"],
+    configs = configs,
     frameworks = [
         "$SDKROOT/System/Library/Frameworks/CoreGraphics.framework",
         "$SDKROOT/System/Library/Frameworks/Foundation.framework",
@@ -41,27 +53,11 @@ apple_bundle(
 
 apple_binary(
     name = "DemoWatchAppBinary",
+    configs = configs,
 )
 
 apple_resource(
     name = "DemoWatchAppResources",
     dirs = [],
     files = ["WatchApplication/Interface.storyboard"],
-)
-
-apple_binary(
-    name = "DemoAppBinary",
-    srcs = glob([
-        "*.m",
-    ]),
-    compiler_flags = ["-fobjc-arc"],
-    frameworks = [
-        "$SDKROOT/System/Library/Frameworks/CoreGraphics.framework",
-        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
-        "$SDKROOT/System/Library/Frameworks/UIKit.framework",
-        "$SDKROOT/System/Library/Frameworks/WatchConnectivity.framework",
-    ],
-    headers = glob([
-        "*.h",
-    ]),
 )

--- a/Watch/BUCK
+++ b/Watch/BUCK
@@ -1,0 +1,64 @@
+apple_binary(
+    name = "DemoWatchAppExtensionBinary",
+    srcs = glob([
+        "WatchExtension/**/*.m",
+    ]),
+    compiler_flags = ["-fobjc-arc"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/CoreGraphics.framework",
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+        "$SDKROOT/System/Library/Frameworks/UIKit.framework",
+        "$SDKROOT/System/Library/Frameworks/WatchConnectivity.framework",
+        "$SDKROOT/System/Library/Frameworks/WatchKit.framework",
+    ],
+    headers = glob([
+        "WatchExtension/**/*.h",
+    ]),
+)
+
+apple_bundle(
+    name = "DemoWatchAppExtension",
+    binary = ":DemoWatchAppExtensionBinary",
+    extension = "appex",
+    info_plist = "WatchExtension/Resources/Info.plist",
+    xcode_product_type = "com.apple.product-type.watchkit2-extension",
+)
+
+apple_bundle(
+    name = "DemoWatchApp",
+    binary = ":DemoWatchAppBinary",
+    extension = "app",
+    info_plist = "WatchApplication/Info.plist",
+    xcode_product_type = "com.apple.product-type.application.watchapp2",
+    deps = [
+        ":DemoWatchAppExtension",
+        ":DemoWatchAppResources",
+    ],
+)
+
+apple_binary(
+    name = "DemoWatchAppBinary",
+)
+
+apple_resource(
+    name = "DemoWatchAppResources",
+    dirs = [],
+    files = ["WatchApplication/Interface.storyboard"],
+)
+
+apple_binary(
+    name = "DemoAppBinary",
+    srcs = glob([
+        "*.m",
+    ]),
+    compiler_flags = ["-fobjc-arc"],
+    frameworks = [
+        "$SDKROOT/System/Library/Frameworks/CoreGraphics.framework",
+        "$SDKROOT/System/Library/Frameworks/Foundation.framework",
+        "$SDKROOT/System/Library/Frameworks/UIKit.framework",
+        "$SDKROOT/System/Library/Frameworks/WatchConnectivity.framework",
+    ],
+    headers = glob([
+        "*.h",
+    ]),
+)

--- a/Watch/BUCK
+++ b/Watch/BUCK
@@ -1,6 +1,7 @@
 config = {
     "SDKROOT": "watchos",
     "WATCHOS_DEPLOYMENT_TARGET": "4.0",
+    "TARGETED_DEVICE_FAMILY": "4",
 }
 
 configs = {

--- a/Watch/BUCK
+++ b/Watch/BUCK
@@ -27,6 +27,9 @@ apple_bundle(
 apple_bundle(
     name = "DemoWatchApp",
     binary = ":DemoWatchAppBinary",
+    visibility = [
+        "//App:",
+    ],
     extension = "app",
     info_plist = "WatchApplication/Info.plist",
     xcode_product_type = "com.apple.product-type.application.watchapp2",

--- a/Watch/WatchApplication/Info.plist
+++ b/Watch/WatchApplication/Info.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Example</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.DemoApp.WatchApp</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>WatchSimulator</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>DTPlatformName</key>
+	<string>watchsimulator</string>
+	<key>DTSDKName</key>
+	<string>watchsimulator2.0</string>
+	<key>SBAppTags</key>
+	<array>
+		<string>hidden</string>
+	</array>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>4</integer>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.example.DemoApp</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/Watch/WatchApplication/Info.plist
+++ b/Watch/WatchApplication/Info.plist
@@ -34,10 +34,6 @@
 	<array>
 		<string>hidden</string>
 	</array>
-	<key>UIDeviceFamily</key>
-	<array>
-		<integer>4</integer>
-	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Watch/WatchApplication/Interface.storyboard
+++ b/Watch/WatchApplication/Interface.storyboard
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6724" systemVersion="14B25" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6711"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="3735"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="aou-V4-d1y">
+            <objects>
+                <controller id="AgC-eL-Hgc" customClass="InterfaceController">
+                    <items>
+                        <button width="1" alignment="left" title="Tap me!" id="nC8-oQ-gKx">
+                            <connections>
+                                <action selector="buttonTapped:" destination="AgC-eL-Hgc" id="UuB-2C-nda"/>
+                            </connections>
+                        </button>
+                    </items>
+                    <connections>
+                        <outlet property="button" destination="nC8-oQ-gKx" id="K1k-5x-fqk"/>
+                    </connections>
+                </controller>
+            </objects>
+            <point key="canvasLocation" x="235" y="347"/>
+        </scene>
+        <!--Glance Interface Controller-->
+        <scene sceneID="BOz-TT-tkC">
+            <objects>
+                <glanceController spacing="0.0" id="0uZ-2p-rRc" customClass="GlanceController">
+                    <items>
+                        <group alignment="left" id="t8f-Gd-c4y"/>
+                        <group alignment="left" id="uCw-4Q-Ouw"/>
+                    </items>
+                    <edgeInsets key="margins" left="0.0" right="0.0" top="0.0" bottom="14"/>
+                </glanceController>
+            </objects>
+            <point key="canvasLocation" x="235" y="672"/>
+        </scene>
+        <!--Static Notification Interface Controller-->
+        <scene sceneID="AEw-b0-oYE">
+            <objects>
+                <notificationController id="YCC-NB-fut">
+                    <items>
+                        <label alignment="left" text="Alert Label" id="XkS-y5-khE"/>
+                    </items>
+                    <notificationCategory key="notificationCategory" id="JfB-70-Muf"/>
+                    <connections>
+                        <outlet property="notificationAlertLabel" destination="XkS-y5-khE" id="49B-RR-99y"/>
+                        <segue destination="gdX-wl-uQE" kind="relationship" relationship="dynamicNotificationInterface" id="fKh-qV-3T2"/>
+                    </connections>
+                </notificationController>
+            </objects>
+            <point key="canvasLocation" x="235" y="1001"/>
+        </scene>
+        <!--Notification Controller-->
+        <scene sceneID="KIl-fV-djm">
+            <objects>
+                <controller id="gdX-wl-uQE" customClass="NotificationController"/>
+            </objects>
+            <point key="canvasLocation" x="553" y="1001"/>
+        </scene>
+    </scenes>
+</document>

--- a/Watch/WatchExtension/ExtensionDelegate.h
+++ b/Watch/WatchExtension/ExtensionDelegate.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#import <WatchKit/WatchKit.h>
+
+@interface ExtensionDelegate : NSObject<WKExtensionDelegate>
+
+@end

--- a/Watch/WatchExtension/ExtensionDelegate.m
+++ b/Watch/WatchExtension/ExtensionDelegate.m
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#import "ExtensionDelegate.h"
+
+#import <WatchConnectivity/WatchConnectivity.h>
+
+#import "WatchExtensionManager.h"
+
+@interface ExtensionDelegate()<WCSessionDelegate>
+
+@end
+
+
+@implementation ExtensionDelegate
+
+- (void)applicationDidFinishLaunching {
+  [[WatchExtensionManager sharedInstance] appDidStart];
+    // Perform any final initialization of your application.
+
+  if ([WCSession isSupported]) {
+    WCSession *session  = [WCSession defaultSession];
+    session.delegate = self;
+    [session activateSession];
+  }
+
+}
+
+- (void)session:(nonnull WCSession *)session didReceiveMessage:(nonnull NSDictionary<NSString *,id> *)message
+{
+  NSLog(@"Did receive message %@", message);
+}
+
+@end

--- a/Watch/WatchExtension/InterfaceController.h
+++ b/Watch/WatchExtension/InterfaceController.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <WatchKit/WatchKit.h>
+
+@interface InterfaceController : WKInterfaceController
+
+@end

--- a/Watch/WatchExtension/InterfaceController.m
+++ b/Watch/WatchExtension/InterfaceController.m
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#import "InterfaceController.h"
+
+
+@interface InterfaceController()
+
+@property (weak, nonatomic) IBOutlet WKInterfaceButton *button;
+@property (weak, nonatomic) IBOutlet WKInterfacePicker *picker;
+
+@end
+
+
+@implementation InterfaceController
+{
+  NSArray *_pickerItems;
+}
+
+- (void)awakeWithContext:(id)context {
+  [super awakeWithContext:context];
+
+  [self _initializePickerItems];
+  [_picker setItems:_pickerItems];
+}
+
+- (void)_initializePickerItems
+{
+  WKPickerItem *itemIOS = [[WKPickerItem alloc] init];
+  itemIOS.title = @"iPhoneOS";
+
+  WKPickerItem *itemWatchOS = [[WKPickerItem alloc] init];
+  itemIOS.title = @"WatchOS";
+
+  WKPickerItem *itemOSX = [[WKPickerItem alloc] init];
+  itemIOS.title = @"MacOSX";
+
+  _pickerItems = @[itemIOS, itemWatchOS, itemOSX];
+}
+
+- (void)willActivate {
+  // This method is called when watch view controller is about to be visible to user
+  [super willActivate];
+}
+
+- (void)didDeactivate {
+  // This method is called when watch view controller is no longer visible
+  [super didDeactivate];
+}
+
+- (IBAction)buttonTapped:(id)sender
+{
+  [_button setTitle:@"Tapped!!"];
+}
+
+- (IBAction)pickerChanged:(NSInteger)value
+{
+  [_button setTitle:[NSString stringWithFormat:@"%@ selected", [_pickerItems[value] title]]];
+}
+
+@end

--- a/Watch/WatchExtension/NotificationController.h
+++ b/Watch/WatchExtension/NotificationController.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#import <Foundation/Foundation.h>
+#import <WatchKit/WatchKit.h>
+
+@interface NotificationController : WKUserNotificationInterfaceController
+
+@end

--- a/Watch/WatchExtension/NotificationController.m
+++ b/Watch/WatchExtension/NotificationController.m
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#import "NotificationController.h"
+
+
+@interface NotificationController()
+
+@end
+
+
+@implementation NotificationController
+
+- (instancetype)init {
+    self = [super init];
+    if (self){
+        // Initialize variables here.
+        // Configure interface objects here.
+
+    }
+    return self;
+}
+
+- (void)willActivate {
+    // This method is called when watch view controller is about to be visible to user
+    [super willActivate];
+}
+
+- (void)didDeactivate {
+    // This method is called when watch view controller is no longer visible
+    [super didDeactivate];
+}
+
+/*
+- (void)didReceiveLocalNotification:(UILocalNotification *)localNotification withCompletion:(void (^)(WKUserNotificationInterfaceType))completionHandler {
+    // This method is called when a local notification needs to be presented.
+    // Implement it if you use a dynamic notification interface.
+    // Populate your dynamic notification inteface as quickly as possible.
+    //
+    // After populating your dynamic notification interface call the completion block.
+    completionHandler(WKUserNotificationInterfaceTypeCustom);
+}
+*/
+
+/*
+- (void)didReceiveRemoteNotification:(NSDictionary *)remoteNotification withCompletion:(void (^)(WKUserNotificationInterfaceType))completionHandler {
+    // This method is called when a remote notification needs to be presented.
+    // Implement it if you use a dynamic notification interface.
+    // Populate your dynamic notification inteface as quickly as possible.
+    //
+    // After populating your dynamic notification interface call the completion block.
+    completionHandler(WKUserNotificationInterfaceTypeCustom);
+}
+*/
+
+@end

--- a/Watch/WatchExtension/Resources/Info.plist
+++ b/Watch/WatchExtension/Resources/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ExampleWatchExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.example.DemoApp.WatchApp.watchkitextension</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>com.example.DemoApp.WatchApp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>RemoteInterfacePrincipalClass</key>
+	<string>InterfaceController</string>
+    <key>WKExtensionDelegateClassName</key>
+    <string>ExtensionDelegate</string></dict>
+</plist>

--- a/Watch/WatchExtension/WatchExtensionManager.h
+++ b/Watch/WatchExtension/WatchExtensionManager.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#import <Foundation/Foundation.h>
+
+@interface WatchExtensionManager : NSObject
+
++ (instancetype)sharedInstance;
+
+- (void)appDidStart;
+
+@end

--- a/Watch/WatchExtension/WatchExtensionManager.m
+++ b/Watch/WatchExtension/WatchExtensionManager.m
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+#import "WatchExtensionManager.h"
+
+@implementation WatchExtensionManager
+
++ (instancetype)sharedInstance
+{
+  static WatchExtensionManager *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [WatchExtensionManager new];
+  });
+  return sharedInstance;
+}
+
+- (void)appDidStart
+{
+  NSLog(@"Yo, started with buck");
+}
+
+@end


### PR DESCRIPTION
This PR brings [Facebook's test data for an Apple Watch app](https://github.com/facebook/buck/tree/a6c7d7391a7a8e575c6372cac6690a240b5907ea/test/com/facebook/buck/apple/testdata/watch_application_bundle) into our repo.

Currently the Buck CLI build (`make build`) completes but the generated Xcode project fails to build.

### Steps to reproduce failure

1. `make install_buck` to install Buck
2. `make project` which will generate the Xcode projects and open the workspace
3. Build the project

### Description of failure

<img width="1512" alt="Screen Shot 2019-03-08 at 8 15 03 PM" src="https://user-images.githubusercontent.com/1791049/54066076-e90d0300-41de-11e9-82a2-739a8a9df194.png">

Xcode is unable to copy `DemoWatchApp.app`.

It's looking for this file at `~/Library/Developer/Xcode/DerivedData/ExampleApp-fvptulkqmgenquarnbxhdyidscth/Build/Products/Debug-iphonesimulator/DemoWatchApp.app` (on my machine).

**Xcode _should_ be looking under `Debug-watchsimulator` instead of `Debug-iphonesimulator`.** 

If you look up `DemoWatchApp.app` in the Project Navigator you can see that it's not being found.
<img width="293" alt="Screen Shot 2019-03-08 at 8 20 35 PM" src="https://user-images.githubusercontent.com/1791049/54066114-bca5b680-41df-11e9-821a-60480c480cdc.png">

Looking under `Debug-watchsimulator` instead of `Debug-iphonesimulator`, the file does in fact exist.

<img width="1169" alt="Screen Shot 2019-03-08 at 8 21 45 PM" src="https://user-images.githubusercontent.com/1791049/54066121-cfb88680-41df-11e9-8a30-42f6c27e095d.png">

If you manually edit the generated project to make `DemoWatchApp.app` point to the file under `Debug-watchsimulator`, the build will succeed.

<img width="489" alt="Screen_Shot_2019-03-08_at_8_27_35_PM" src="https://user-images.githubusercontent.com/1791049/54066172-bfed7200-41e0-11e9-9afb-06a52126d1a6.png">


I created a new WatchKit project using the Xcode creation wizard. You'll notice that the Watch app has a nice watch logo, which we don't see in our project.
<img width="293" alt="Screen Shot 2019-03-08 at 8 23 56 PM" src="https://user-images.githubusercontent.com/1791049/54066146-38076800-41e0-11e9-9ed2-03ab2f28820a.png">


It seems as if Xcode doesn't realize this build product is a watch app. That could explain why it's looking in the wrong place for the build product....

### Configuration

**Xcode version:** 10.1 (10B61)


-------

## TODO

- [ ] Add code into the example project's app delegate (see [Facebook code](https://github.com/facebook/buck/blob/a6c7d7391a7a8e575c6372cac6690a240b5907ea/test/com/facebook/buck/apple/testdata/watch_application_bundle/ExampleAppDelegate.m#L33-L71)) to talk to the watch app.