### PR TITLE
Add  dynamic framework to BuckSample

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -75,9 +75,6 @@ apple_library(
     ]
     + first_party_library_dependencies
     + build_phase_scripts,
-    # The library doesn't necessarily need to depend on frameworks for Buck CLI.
-    # It's a hack to make generated project link to the frameworks.
-    + first_party_frameworks,
 )
 
 apple_binary(

--- a/App/BUCK
+++ b/App/BUCK
@@ -1,6 +1,5 @@
 load("//Config:configs.bzl", "app_binary_configs", "library_configs", "watch_binary_configs", "message_binary_configs", "pretty", "info_plist_substitutions", "bundle_identifier", "DEVELOPMENT_LANGUAGE")
 load("//Config:buck_rule_macros.bzl", "apple_lib", "apple_test_lib", "apple_test_all")
-load("//Config:frameworks.bzl", "first_party_frameworks")
 
 apple_asset_catalog(
     name = "ExampleAppAssets",
@@ -75,9 +74,6 @@ apple_library(
     ]
     + first_party_library_dependencies
     + build_phase_scripts
-    # The library doesn't necessarily need to depend on frameworks for Buck CLI.
-    # It's a hack to make generated project link to the frameworks.
-    + first_party_frameworks,
 )
 
 apple_binary(
@@ -121,8 +117,11 @@ xcode_postbuild_script(
 apple_test_all(
     name = "ExampleAppCITests",
     libraries = first_party_library_dependencies,
-    additional_tests = app_tests + first_party_frameworks,
+    additional_tests = app_tests,
     prebuilt_frameworks = prebuilt_frameworks,
+    deps = [
+        "//Libraries/SwiftShared:SwiftSharedFramework",
+    ],
 )
 
 xcode_workspace_config(
@@ -150,7 +149,9 @@ apple_bundle(
     product_name = "ExampleApp",
     info_plist = "Info.plist",
     info_plist_substitutions = info_plist_substitutions("ExampleApp"),
-    deps = first_party_frameworks + [
+    deps = [
+        "//Libraries/SwiftShared:SwiftSharedFramework",
+    ] + [
         # For "#watch", https://buckbuild.com/rule/apple_bundle.html#deps
         ":ExampleWatchApp#watch",
         ":ExampleMessageExtension",

--- a/App/BUCK
+++ b/App/BUCK
@@ -312,6 +312,7 @@ apple_test_lib(
     ]),
     deps = [
         ":ExampleAppLibrary",
+        "//Libraries/SwiftShared:SwiftSharedFramework",
     ]
     + prebuilt_frameworks,
 )

--- a/App/BUCK
+++ b/App/BUCK
@@ -74,7 +74,10 @@ apple_library(
         "//App/Resources:StoryboardResources",
     ]
     + first_party_library_dependencies
-    + build_phase_scripts,
+    + build_phase_scripts
+    # The library doesn't necessarily need to depend on frameworks for Buck CLI.
+    # It's a hack to make generated project link to the frameworks.
+    + first_party_frameworks,
 )
 
 apple_binary(
@@ -271,9 +274,7 @@ apple_binary(
 
     deps = [
         "//Libraries/SwiftShared:SwiftShared",
-    ]
-    # See ":ExampleApp" for why this need to depend on frameworks.
-    + first_party_frameworks
+    ],
 )
 
 apple_bundle(

--- a/App/BUCK
+++ b/App/BUCK
@@ -1,5 +1,6 @@
 load("//Config:configs.bzl", "app_binary_configs", "library_configs", "watch_binary_configs", "message_binary_configs", "pretty", "info_plist_substitutions", "bundle_identifier", "DEVELOPMENT_LANGUAGE")
 load("//Config:buck_rule_macros.bzl", "apple_lib", "apple_test_lib", "apple_test_all")
+load("//Config:frameworks.bzl", "first_party_frameworks")
 
 apple_asset_catalog(
     name = "ExampleAppAssets",
@@ -31,6 +32,7 @@ first_party_library_dependencies = [
     "//Libraries/SwiftWithMLModel:SwiftWithMLModel",
     "//Libraries/SwiftWithPrecompiledDependency:SwiftWithPrecompiledDependency",
     "//Libraries/YetAnotherSwiftModule:YetAnotherSwiftModule",
+    "//Libraries/SwiftShared:SwiftShared",
 ]
 
 prebuilt_frameworks = [
@@ -73,6 +75,9 @@ apple_library(
     ]
     + first_party_library_dependencies
     + build_phase_scripts,
+    # The library doesn't necessarily need to depend on frameworks for Buck CLI.
+    # It's a hack to make generated project link to the frameworks.
+    + first_party_frameworks,
 )
 
 apple_binary(
@@ -116,7 +121,7 @@ xcode_postbuild_script(
 apple_test_all(
     name = "ExampleAppCITests",
     libraries = first_party_library_dependencies,
-    additional_tests = app_tests,
+    additional_tests = app_tests + first_party_frameworks,
     prebuilt_frameworks = prebuilt_frameworks,
 )
 
@@ -145,10 +150,10 @@ apple_bundle(
     product_name = "ExampleApp",
     info_plist = "Info.plist",
     info_plist_substitutions = info_plist_substitutions("ExampleApp"),
-    deps = [
+    deps = first_party_frameworks + [
         # For "#watch", https://buckbuild.com/rule/apple_bundle.html#deps
         ":ExampleWatchApp#watch",
-        ":ExampleMessageExtension"
+        ":ExampleMessageExtension",
     ]
     + prebuilt_frameworks,
 )
@@ -266,6 +271,12 @@ apple_binary(
         "-Xlinker",
         "@executable_path/../../Frameworks",
     ],
+
+    deps = [
+        "//Libraries/SwiftShared:SwiftShared",
+    ]
+    # See ":ExampleApp" for why this need to depend on frameworks.
+    + first_party_frameworks
 )
 
 apple_bundle(

--- a/App/MessageExtension/MessagesViewController.swift
+++ b/App/MessageExtension/MessagesViewController.swift
@@ -8,12 +8,16 @@
 
 import UIKit
 import Messages
+import SwiftShared
 
 class MessagesViewController: MSMessagesAppViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        
+        // Init a class from a shared framework
+        let shared = PublicSharedClass()
+        print("From shared resource: \(shared.readFromResource())")
     }
     
     // MARK: - Conversation Handling

--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -11,6 +11,7 @@ import SwiftWithAssets
 import SwiftWithMLModel
 import SwiftWithPrecompiledDependency
 import YetAnotherSwiftModule
+import SwiftShared
 import UIKit
 
 public let testVar = "SampleValue"
@@ -116,5 +117,9 @@ class ViewController: UIViewController {
     }
 
     print("AFNetworking's version is \(SwiftWithPrecompiledDependencyClass.networkingLibraryVersionNumber)")
+
+    // Init a class from a shared framework
+    let shared = PublicSharedClass()
+    print("From shared resource: \(shared.readFromResource())")
   }
 }

--- a/Config/buck_rule_macros.bzl
+++ b/Config/buck_rule_macros.bzl
@@ -86,13 +86,14 @@ def apple_test_all(
         libraries = [],
         additional_tests = [],
         prebuilt_frameworks = [],
+        deps = [],
         **kwargs):
     ci_test_libraries = []
     for library in libraries:
         ci_test_libraries.append(ci_test_name(test_name(library)))
 
     apple_test_lib(
-        deps = ci_test_libraries + additional_tests + prebuilt_frameworks,
+        deps = ci_test_libraries + additional_tests + prebuilt_frameworks + deps,
         bundle_for_ci = False,
         **kwargs
     )

--- a/Config/buck_rule_macros.bzl
+++ b/Config/buck_rule_macros.bzl
@@ -233,12 +233,14 @@ def first_party_framework(
     lib_test_name = test_name(name)
 
     apple_lib(
-        name,
+        name = name,
         srcs = native.glob(["Sources/**/*.swift"]),
         exported_headers = exported_headers,
         configs = framework_configs(framework_name),
         # Setting preferred_linkage to shared is the key to make a dylib.
         preferred_linkage = "shared",
+        compiler_flags = ["-fapplication-extension"],
+        swift_compiler_flags= ["-application-extension"],
         # Set the install_name so consumers of this dylib know where to find it.
         linker_flags = ["-Wl,-install_name,@rpath/%s.framework/%s" % (name, name)],
         deps = deps + ([":" + resource_name] if has_resource else []),

--- a/Config/buck_rule_macros.bzl
+++ b/Config/buck_rule_macros.bzl
@@ -15,15 +15,6 @@ def ci_test_name(name):
 
 DEFAULT_SWIFT_VERSION = "4.0"
 
-def shared_plist_info_substitutions(name):
-    substitutions = {
-        "CURRENT_PROJECT_VERSION": "1",
-        "DEVELOPMENT_LANGUAGE": "en-us",
-        "EXECUTABLE_NAME": name,
-        "PRODUCT_NAME": name,
-    }
-    return substitutions
-
 # Use this macro to declare test targets. For first-party libraries, use first_party_library to declare a test target instead.
 # This macro defines two targets.
 # 1. An apple_test target comprising `srcs`. This test target is picked up by Xcode, and is runnable from Buck.
@@ -68,7 +59,6 @@ def apple_test_lib(
         "PRODUCT_NAME": name,
     }
     substitutions.update(info_plist_substitutions)
-    substitutions.update({"PRODUCT_BUNDLE_IDENTIFIER": "com.airbnb.%s" % test_name})
     native.apple_test(
         name = name,
         visibility = visibility,
@@ -255,8 +245,13 @@ def first_party_framework(
         tests = [":" + lib_test_name],
     )
 
-    substitutions = shared_plist_info_substitutions(name)
-    substitutions.update({"PRODUCT_BUNDLE_IDENTIFIER": "com.airbnb.%s" % framework_name})
+    substitutions = {
+        "CURRENT_PROJECT_VERSION": "1",
+        "DEVELOPMENT_LANGUAGE": "en-us",
+        "EXECUTABLE_NAME": name,
+        "PRODUCT_NAME": name,
+        "PRODUCT_BUNDLE_IDENTIFIER": "com.airbnb.%s" % framework_name,
+    }
     native.apple_bundle(
         name = framework_name,
         product_name = name,

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -62,6 +62,17 @@ def app_binary_configs(name):
     binary_config = config_with_updated_linker_flags(binary_config, ALL_LOAD_LINKER_FLAG)
     return configs_with_config(binary_config)
 
+def framework_configs(name):
+    framework_specific_config = {
+        "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
+    }
+    framework_config = SHARED_CONFIGS + framework_specific_config
+    configs = {
+        "Debug": framework_config,
+        "Profile": framework_config,
+    }
+    return configs
+
 def test_configs(name):
     binary_specific_config = info_plist_substitutions(name)
     binary_config = SHARED_CONFIGS + binary_specific_config
@@ -86,6 +97,7 @@ def info_plist_substitutions(name):
         "EXECUTABLE_NAME": name,
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
         "PRODUCT_NAME": name,
+        "CURRENT_PROJECT_VERSION": "1.0"
     }
     return substitutions
 

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -65,6 +65,7 @@ def app_binary_configs(name):
 def framework_configs(name):
     framework_specific_config = {
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
+        "MACH_O_TYPE": "mh_dylib",
     }
     framework_config = SHARED_CONFIGS + framework_specific_config
     configs = {

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -66,11 +66,13 @@ def framework_configs(name):
     framework_specific_config = {
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
         "MACH_O_TYPE": "mh_dylib",
+        "APPLICATION_EXTENSION_API_ONLY": "YES",
     }
     framework_config = SHARED_CONFIGS + framework_specific_config
     configs = {
         "Debug": framework_config,
         "Profile": framework_config,
+        "Release": framework_config,
     }
     return configs
 

--- a/Config/frameworks.bzl
+++ b/Config/frameworks.bzl
@@ -1,0 +1,5 @@
+# This file contains all first party frameworks
+
+first_party_frameworks = [
+    "//Libraries/SwiftShared:SwiftSharedFramework",
+]

--- a/Config/frameworks.bzl
+++ b/Config/frameworks.bzl
@@ -1,5 +1,0 @@
-# This file contains all first party frameworks
-
-first_party_frameworks = [
-    "//Libraries/SwiftShared:SwiftSharedFramework",
-]

--- a/Libraries/SwiftShared/BUCK
+++ b/Libraries/SwiftShared/BUCK
@@ -1,0 +1,8 @@
+load("//Config:buck_rule_macros.bzl", "first_party_framework")
+
+first_party_framework(
+    name = "SwiftShared",
+    exported_headers = glob(["Sources/**/*.h"]),
+    has_resource = True,
+    resource_files = glob(["Resources/**/*.*"]),
+)

--- a/Libraries/SwiftShared/Info.plist
+++ b/Libraries/SwiftShared/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/Libraries/SwiftShared/Resources/plaintext.txt
+++ b/Libraries/SwiftShared/Resources/plaintext.txt
@@ -1,0 +1,1 @@
+Hello, Buck!

--- a/Libraries/SwiftShared/Sources/PublicSharedClass.swift
+++ b/Libraries/SwiftShared/Sources/PublicSharedClass.swift
@@ -1,0 +1,20 @@
+//
+//  Created by Qing Yang on 3/13/19.
+//  Copyright © 2019 Airbnb. All rights reserved.
+//
+
+import Foundation
+
+public class PublicSharedClass {
+  public init () {
+  }
+
+  public func readFromResource() -> String {
+    if let filepath = Bundle(for: type(of: self)).path(forResource: "plaintext", ofType: "txt"),
+       let content = try? String(contentsOfFile: filepath) {
+      return content
+    } else {
+      return "Not Found!"
+    }
+  }
+}

--- a/Libraries/SwiftShared/Tests/Info.plist
+++ b/Libraries/SwiftShared/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Libraries/SwiftShared/Tests/SwiftSharedTests.swift
+++ b/Libraries/SwiftShared/Tests/SwiftSharedTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+@testable import SwiftShared
+
+final class SwiftSharedTests: XCTestCase {
+  func test_readResource() {
+    let content = PublicSharedClass().readFromResource()
+    XCTAssertEqual(content, "Hello, Buck!")
+  }
+}


### PR DESCRIPTION
This PR unlocks the ability of adding dynamic frameworks which can be shared between bundles (App, Extension or Framework). It works in Buck CLI and generated workspace.

A shared module named `SwiftShared` is added and imported into `ExampleApp` and `ExampleMessageExtension`. 

The bare bone of the BUCK rules look like this:

- The BUCK file for `SwiftShared`:
``` python
apple_library(
    name = "SwiftShared",
    # Setting preferred_linkage to shared makes this a dylib. 
    preferred_linkage = "shared",
    # Set the install_name so consumers of this dylib know where to find it.
    linker_flags = ["-Wl,-install_name,@rpath/%s.framework/%s" % (name, name)],
    configs = { "Debug": {
        # Make this a dylib in Xcode
        "MACH_O_TYPE": "mh_dylib",
    }},
)

apple_bundle(
    name = "SwiftSharedFramework",
    # Specifying the the flavor "shared" makes this a dynamic framework
    binary = ":SwiftShared#shared",
    extension = "framework",
)
```
- The BUCK file for the app:
``` python
apple_binary(
    name = "ExampleAppBinary",
    # The app binary depends on the library
    deps = [
         ":SwiftShared",
    ],
)

apple_bundle(
    name = "ExampleApp",
    binary = ":ExampleAppBinary",
    extension = "app",
    # the app bundle depends on the framework
    deps = [":SwiftSharedFramework"],
)
```
A library is a file where binary code lives, while a framework is a directory (bundle) containing a library and some resources. `ExampleAppBinary` depends on `SwiftShared` library because the binary needs to know where the actual code is, and the dependency from `ExmapleApp` bundle to `SwiftSharedFramework` simply copies the framework to app bundle (`ExmapleApp.app`). That being said, an extension only needs to depend on the library to compile, not the framework, since the main app bundle is the one who copies over the framework.

## Verification
* binary from Buck CLI build has undefined symbols from `SwiftShared`
![image](https://user-images.githubusercontent.com/6559265/58067842-bd45bc00-7b43-11e9-9f70-902a78e0b594.png)

* binary from Xcode build has undefined symbols from `SwiftShared`
![image](https://user-images.githubusercontent.com/6559265/58067857-d2bae600-7b43-11e9-8454-fcaa3307c5c4.png)


