### PR TITLE
Use `-all_load` for binaries in Buck-generated project to work around Apple bug

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -1,4 +1,4 @@
-load("//Config:configs.bzl", "binary_configs", "library_configs", "watch_binary_configs", "message_binary_configs", "pretty", "info_plist_substitutions")
+load("//Config:configs.bzl", "app_binary_configs", "library_configs", "watch_binary_configs", "message_binary_configs", "pretty", "info_plist_substitutions")
 load("//Config:buck_rule_macros.bzl", "apple_lib", "apple_test_lib", "apple_test_all")
 
 apple_asset_catalog(
@@ -55,7 +55,7 @@ apple_binary(
         "//App:",
         "//App/...",
     ],
-    configs = binary_configs("ExampleApp"),
+    configs = app_binary_configs("ExampleApp"),
     swift_version = "4.0",
     srcs = [
         "BuckSupportFiles/Dummy.swift",
@@ -202,7 +202,7 @@ apple_binary(
         "MessageExtension/**/*.swift",
     ]),
     configs = message_binary_configs("ExampleApp.MessageExtension"),
-    
+
     # "-e _NSExtensionMain" tell linker this binary is app extension, so it won't fail due to missing _main
     # "-Xlinker -rpath -Xlinker @executable_path/../../Frameworks" tells the executable binary to
     # look for frameworks in ExampleApp.app/Frameworks instead of PlugIns, so that we don't need to have

--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -83,8 +83,9 @@ class ViewController: UIViewController {
     //
     // `-force_load`ing the module where the conformance exists also works.
     //
-    // This is tracked by https://bugs.swift.org/browse/SR-6004. This seems to indicate that
-    // `-all_load` will work too, but we haven't verified that.
+    // Finally, you can use `-all_load`. **That is the workaround that we are currently using.**
+    //
+    // This is tracked by https://bugs.swift.org/browse/SR-6004.
 //    let myObject = MyPublicClass()
     let myObject = MyFactory.myPublicObject()
     if (myObject as? MyPublicProtocol) == nil {

--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -67,26 +67,22 @@ class ViewController: UIViewController {
     // This line will crash if the assets from SwiftWithAssets haven't been bundled into the app
     _ = Catalog.buck.image
 
-    // Without an object explicitly typed as `MyPublicClass`, an instance of `MyPublicClass` won't
-    // exhibit conformance to `MyPublicProtocol`. `MyPublicClass` is defined in `Swift4`.
-    // `MyPublicProtocol` and the conformance of `MyPublicClass` to `MyPublicProtocol` is defined in
-    // `Swift3`.
+    // Without an object explicitly typed as `MyPublicClass` in this module, an instance of
+    // `MyPublicClass` won't exhibit conformance to `MyPublicProtocol`. `MyPublicClass` is defined
+    // in `Swift4`. `MyPublicProtocol` and the conformance of `MyPublicClass` to `MyPublicProtocol`
+    // is defined in `Swift3`.
     //
-    // One workaround when possible is to make sure the object is explictly typed as `MyPublicClass`
-    // and avoid type erasure. You can see this in action by swapping the way that we are creating
-    // `myObject` below to be `MyPublicClass()` instead of `MyFactory.myPublicObject()`.
+    // We are currently working around this issue in the Buck-generated project by including the
+    // `-all_load` flag for `OTHER_LDFLAGS` in the `configs` that we are passing to all
+    // `apple_binary()` invocations.
     //
-    // Avoiding type erasure is not always possible though. Another way to workaround this bug is to
-    // annotate `MyPublicProtocol` with `@objc`. We pass `-ObjC` to "Other Linker Flags", which will
-    // cause this conformance to not be stripped. Annotating the actual conformance of
-    // `MyPublicClass` to `MyPublicProtocol` will also work and is a bit less invasive.
+    // Other known workarounds:
+    // * Annotate `MyPublicProtocol` with `@objc` and pass the `-ObjC` flag to `OTHER_LDFLAGS`.
+    // * Annotate the conformance of `MyPublicClass` to `MyPublicProtocol` with `@objc` and pass
+    // the `-ObjC` flag to `OTHER_LDFLAGS`.
+    // * `-force_load` the module where the conformance exists. In this case that would be `Swift3`.
     //
-    // `-force_load`ing the module where the conformance exists also works.
-    //
-    // Finally, you can use `-all_load`. **That is the workaround that we are currently using.**
-    //
-    // This is tracked by https://bugs.swift.org/browse/SR-6004.
-//    let myObject = MyPublicClass()
+    // This bug is documented at https://bugs.swift.org/browse/SR-6004.
     let myObject = MyFactory.myPublicObject()
     if (myObject as? MyPublicProtocol) == nil {
       print("Incorrect: `MyPublicProtocol` conformance is being erroneously stripped")

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -1,4 +1,4 @@
-load("//Config:utils.bzl", "config_with_updated_linker_flags")
+load("//Config:utils.bzl", "config_with_updated_linker_flags", "configs_with_config")
 
 def pretty(dict, current = ""):
     current = "\n"

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -44,7 +44,7 @@ def library_configs():
     }
     return configs
 
-def binary_configs(name):
+def app_binary_configs(name):
     binary_specific_config = {
         "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
         "DEVELOPMENT_LANGUAGE": "Swift",

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -28,7 +28,7 @@ SHARED_CONFIGS = {
 
 # Adding `-all_load` to our binaries works around https://bugs.swift.org/browse/SR-6004. See the
 # longer comment in `ViewController.swift` for more details.
-APPLE_BINARY_OTHER_LINKER_FLAGS = "-all_load"
+ALL_LOAD_LINKER_FLAG = "-all_load"
 
 def bundle_identifier(name):
     return "com.airbnb.%s" % name
@@ -57,7 +57,7 @@ def app_binary_configs(name):
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
     }
     binary_config = SHARED_CONFIGS + binary_specific_config
-    binary_config = config_with_updated_linker_flags(binary_config, APPLE_BINARY_OTHER_LINKER_FLAGS)
+    binary_config = config_with_updated_linker_flags(binary_config, ALL_LOAD_LINKER_FLAG)
     return configs_with_config(binary_config)
 
 def test_configs(name):
@@ -97,7 +97,7 @@ def watch_binary_configs(name):
         # Not sure why, but either adding this or removing -whole-module-optimization can make it compile
         "SWIFT_COMPILATION_MODE": "wholemodule"
     }
-    config = config_with_updated_linker_flags(config, APPLE_BINARY_OTHER_LINKER_FLAGS)
+    config = config_with_updated_linker_flags(config, ALL_LOAD_LINKER_FLAG)
     return configs_with_config(config)
 
 def message_binary_configs(name):
@@ -105,5 +105,5 @@ def message_binary_configs(name):
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
         "SWIFT_COMPILATION_MODE": "wholemodule"
     }
-    config = config_with_updated_linker_flags(config, APPLE_BINARY_OTHER_LINKER_FLAGS)
+    config = config_with_updated_linker_flags(config, ALL_LOAD_LINKER_FLAG)
     return configs_with_config(config)

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -55,7 +55,8 @@ def app_binary_configs(name):
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
     }
     binary_config = SHARED_CONFIGS + binary_specific_config
-    binary_config = config_with_updated_linker_flags(binary_config, APPLE_BINARY_OTHER_LINKER_FLAGS)return configs_with_config(binary_config)
+    binary_config = config_with_updated_linker_flags(binary_config, APPLE_BINARY_OTHER_LINKER_FLAGS)
+    return configs_with_config(binary_config)
 
 def test_configs(name):
     binary_specific_config = info_plist_substitutions(name)

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -26,6 +26,8 @@ SHARED_CONFIGS = {
     "LD_RUNPATH_SEARCH_PATHS": "@executable_path/Frameworks", # To allow source files in binary
 }
 
+# Adding `-all_load` to our binaries works around https://bugs.swift.org/browse/SR-6004. See the
+# longer comment in `ViewController.swift` for more details.
 APPLE_BINARY_OTHER_LINKER_FLAGS = "-all_load"
 
 def bundle_identifier(name):

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -1,4 +1,4 @@
-load("//ios/Config:utils.bzl", "config_with_updated_linker_flags")
+load("//Config:utils.bzl", "config_with_updated_linker_flags")
 
 def pretty(dict, current = ""):
     current = "\n"

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -1,3 +1,5 @@
+load("//ios/Config:utils.bzl", "config_with_updated_linker_flags")
+
 def pretty(dict, current = ""):
     current = "\n"
     indent = 0
@@ -23,6 +25,8 @@ SHARED_CONFIGS = {
     "ONLY_ACTIVE_ARCH": "YES",
     "LD_RUNPATH_SEARCH_PATHS": "@executable_path/Frameworks", # To allow source files in binary
 }
+
+APPLE_BINARY_OTHER_LINKER_FLAGS = "-all_load"
 
 def bundle_identifier(name):
     return "com.airbnb.%s" % name
@@ -51,11 +55,7 @@ def app_binary_configs(name):
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
     }
     binary_config = SHARED_CONFIGS + binary_specific_config
-    configs = {
-        "Debug": binary_config,
-        "Profile": binary_config,
-    }
-    return configs
+    binary_config = config_with_updated_linker_flags(binary_config, APPLE_BINARY_OTHER_LINKER_FLAGS)return configs_with_config(binary_config)
 
 def test_configs(name):
     binary_specific_config = info_plist_substitutions(name)
@@ -94,21 +94,13 @@ def watch_binary_configs(name):
         # Not sure why, but either adding this or removing -whole-module-optimization can make it compile
         "SWIFT_COMPILATION_MODE": "wholemodule"
     }
-    configs = {
-        "Debug": config,
-        "Profile": config,
-        "Release": config,
-    }
-    return configs
+    config = config_with_updated_linker_flags(config, APPLE_BINARY_OTHER_LINKER_FLAGS)
+    return configs_with_config(config)
 
 def message_binary_configs(name):
     config = {
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
         "SWIFT_COMPILATION_MODE": "wholemodule"
     }
-    configs = {
-        "Debug": config,
-        "Profile": config,
-        "Release": config,
-    }
-    return configs
+    config = config_with_updated_linker_flags(config, APPLE_BINARY_OTHER_LINKER_FLAGS)
+    return configs_with_config(config)

--- a/Config/utils.bzl
+++ b/Config/utils.bzl
@@ -37,19 +37,12 @@ def configs_with_config(config):
         "Release": config,
     }
 
-def configs_without_key(configs, key):
-    modified_configs = configs.copy()
-    for configs_key in configs:
-        if configs[configs_key].has_key(key):
-            modified_configs[configs_key].pop(key)
-    return modified_configs
-
 # Creates a new dictionary of `configs` that includes `other_linker_flags`.
 # Params:
 # - configs: A dictionary where every key is a build config and the value is another dict of configs for that build
 # - additional_linker_flags: A string-representable value of additional linker flags
 def configs_with_updated_linker_flags(configs, other_linker_flags):
-    if other_linker_flags is None:
+    if other_linker_flags == None:
         return configs
     else:
         updated_configs = { }
@@ -65,9 +58,17 @@ def configs_with_updated_linker_flags(configs, other_linker_flags):
 # - additional_linker_flags: A string-representable value of additional linker flags
 # - config_key: The key to which to append or assign the additional linker flags
 def config_with_updated_linker_flags(config, other_linker_flags, config_key=OTHER_LINKER_FLAGS_KEY):
-    config_copy = config.copy()
-    if config_key in config_copy:
-        config_copy[config_key] += ' ' + other_linker_flags
-    else:
-        config_copy[config_key] = '$(inherited) ' + other_linker_flags
-    return config_copy
+    new_config = { }
+    config_key_found = False
+    for key in config:
+        if key == config_key:
+            new_config[key] = config[key] + (" %s" % other_linker_flags)
+            config_key_found = True
+        else:
+            new_config[key] = config[key]
+
+    if config_key_found == False:
+        # If `config` does not currently contain `config_key`, add it. Inherit for good measure.
+        new_config[config_key] = '$(inherited) ' + other_linker_flags
+
+    return new_config

--- a/Config/utils.bzl
+++ b/Config/utils.bzl
@@ -1,0 +1,73 @@
+OTHER_LINKER_FLAGS_KEY = 'OTHER_LDFLAGS'
+
+# ## Clarification
+#
+# `config` and `configs` dictionaries can be easily confused.
+#
+# A `config` (singular) dictionary is a bag of settings that pertains to a particular build
+# configuration (e.g. Debug, Release).
+#
+# {
+#   "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
+#   "DEVELOPMENT_LANGUAGE": "Swift",
+#   /* ... */
+# }
+#
+# A `configs` (plural) dictionary is a union of `config` dictionaries, keyed by the build
+# configuration.
+#
+# {
+#   "Debug": {
+#     "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
+#     "DEVELOPMENT_LANGUAGE": "Swift",
+#     /* ... */
+#   },
+#   "Release": {
+#     "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
+#     "DEVELOPMENT_LANGUAGE": "Swift",
+#     /* ... */
+#   }
+# }
+
+# Creates a dictionary where the top level keys are the supported build configurations and the value of each key is `config`.
+def configs_with_config(config):
+    return {
+        "Debug": config,
+        "Profile": config,
+        "Release": config,
+    }
+
+def configs_without_key(configs, key):
+    modified_configs = configs.copy()
+    for configs_key in configs:
+        if configs[configs_key].has_key(key):
+            modified_configs[configs_key].pop(key)
+    return modified_configs
+
+# Creates a new dictionary of `configs` that includes `other_linker_flags`.
+# Params:
+# - configs: A dictionary where every key is a build config and the value is another dict of configs for that build
+# - additional_linker_flags: A string-representable value of additional linker flags
+def configs_with_updated_linker_flags(configs, other_linker_flags):
+    if other_linker_flags is None:
+        return configs
+    else:
+        updated_configs = { }
+        for build_configuration in configs:
+            updated_configs[build_configuration] = config_with_updated_linker_flags(
+                configs[build_configuration],
+                other_linker_flags)
+        return updated_configs
+
+# Either appends or assigns `other_linker_flags` to `config` under `config_key`.
+# Params:
+# - config: A dictionary of config names and their values
+# - additional_linker_flags: A string-representable value of additional linker flags
+# - config_key: The key to which to append or assign the additional linker flags
+def config_with_updated_linker_flags(config, other_linker_flags, config_key=OTHER_LINKER_FLAGS_KEY):
+    config_copy = config.copy()
+    if config_key in config_copy:
+        config_copy[config_key] += ' ' + other_linker_flags
+    else:
+        config_copy[config_key] = '$(inherited) ' + other_linker_flags
+    return config_copy


### PR DESCRIPTION
In https://github.com/airbnb/BuckSample/pull/38 I documented [Apple's bug](https://bugs.swift.org/browse/SR-6004) with Swift static libraries that can cause protocol conformances to be stripped under some circumstances.

This bug only manifests in builds produced by Buck-generated projects. It does not manifest in builds from the Buck CLI since those builds do not use Swift static libraries.

We have investigated how best to work around this bug in our Buck-generated projects.

We currently believe that adding `-all_load` to Apple binaries is the best approach.

`-force_load`ing specific static libraries can also work. However, the ergonomics of it aren't as good as you likely need to find and specify each library to `-force_load`. This can quickly become a game of whack-a-mole.

We are planning to ship to the App Store with Buck CLI builds so we won't encounter this issue in production. However, we want our developers to be able to use the Buck-generated projects with confidence and not worry if bugs they see in development are due to this Apple bug. Because we are only using Buck-generated project for development we also don't need to worry about bloating the binary size by adding `-all_load.` 

### Tags for SEO
- SR-6004