### PR TITLE
Update apple_bundle name

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -37,7 +37,7 @@ build_phase_scripts = [
 ]
 
 apple_library(
-    name = "ExampleApp",
+    name = "ExampleAppLibrary",
     visibility = [
         "//App:",
         "//App/...",
@@ -71,7 +71,7 @@ apple_binary(
         "BuckSupportFiles/Dummy.swift",
     ],
     deps = [
-        ":ExampleApp",
+        ":ExampleAppLibrary",
     ],
 )
 
@@ -108,7 +108,7 @@ apple_test_all(
 xcode_workspace_config(
     name = "workspace",
     workspace_name = "ExampleApp",
-    src_target = ":ExampleAppBundle",
+    src_target = ":ExampleApp",
     additional_scheme_actions = {
         "Build": {
             "PRE_SCHEME_ACTIONS": ["echo 'Started'"],
@@ -119,9 +119,10 @@ xcode_workspace_config(
 )
 
 apple_bundle(
-    name = "ExampleAppBundle",
+    name = "ExampleApp",
     visibility = [
         "//App:",
+        "//App/Tests:",
         "//App/UITests:",
     ],
     extension = "app",
@@ -138,7 +139,7 @@ apple_bundle(
 
 apple_package(
     name = "ExampleAppPackage",
-    bundle = ":ExampleAppBundle",
+    bundle = ":ExampleApp",
 )
 
 ### Watch App Begin ###

--- a/App/Tests/BUCK
+++ b/App/Tests/BUCK
@@ -7,6 +7,6 @@ apple_test_lib(
     ]),
     info_plist = "Info.plist",
     deps = [
-        "//App:ExampleApp",
+        "//App:ExampleAppLibrary",
     ],
 )

--- a/App/Tests/BuckSampleTests.swift
+++ b/App/Tests/BuckSampleTests.swift
@@ -6,7 +6,7 @@
 //
 
 import XCTest
-@testable import ExampleApp
+@testable import ExampleAppLibrary
 
 final class BuckSampleTests: XCTestCase {
 

--- a/App/UITests/BUCK
+++ b/App/UITests/BUCK
@@ -2,7 +2,7 @@ load("//Config:buck_rule_macros.bzl", "apple_lib", "apple_test_lib")
 
 apple_test_lib(
     name = "UITests",
-    test_host_app = "//App:ExampleAppBundle",
+    test_host_app = "//App:ExampleApp",
     srcs = [
         "BuckSampleUITests.swift",
     ],

--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -73,10 +73,6 @@ class ViewController: UIViewController {
     // in `Swift4`. `MyPublicProtocol` and the conformance of `MyPublicClass` to `MyPublicProtocol`
     // is defined in `Swift3`.
     //
-    // One workaround when possible is to make sure the object is explictly typed as `MyPublicClass`
-    // and avoid type erasure. You can see this in action by swapping the way that we are creating
-    // `myObject` below to be `MyPublicClass()` instead of `MyFactory.myPublicObject()`.
-    //
     // We are currently working around this issue in the Buck-generated project by including the
     // `-all_load` flag for `OTHER_LDFLAGS` in the `configs` that we are passing to all
     // `apple_binary()` invocations.

--- a/App/ViewController.swift
+++ b/App/ViewController.swift
@@ -73,6 +73,10 @@ class ViewController: UIViewController {
     // in `Swift4`. `MyPublicProtocol` and the conformance of `MyPublicClass` to `MyPublicProtocol`
     // is defined in `Swift3`.
     //
+    // One workaround when possible is to make sure the object is explictly typed as `MyPublicClass`
+    // and avoid type erasure. You can see this in action by swapping the way that we are creating
+    // `myObject` below to be `MyPublicClass()` instead of `MyFactory.myPublicObject()`.
+    //
     // We are currently working around this issue in the Buck-generated project by including the
     // `-all_load` flag for `OTHER_LDFLAGS` in the `configs` that we are passing to all
     // `apple_binary()` invocations.


### PR DESCRIPTION
This makes Buck commands a little more idiomatic. e.g. `buck build //App:ExampleApp`

 * Update the `apple_bundle` name to be `ExampleApp`
 * Update the `apple_library` to be named `ExampleAppLibrar`
 * Add Apple Watch, and other CI checks.