### PR TITLE
Remove ui_test from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,11 @@ debug:
 targets:
 	$(BUCK) targets //...
 
-ci: install_buck targets build test ui_test project xcode_tests watch message
+ci: install_buck targets build test project xcode_tests watch message
 	echo "Done"
 
 test:
 	$(BUCK) test //App:ExampleAppCITests --test-runner-env FOO=BAR
-
-ui_test:
-	$(BUCK) test //App:XCUITests
 
 audit:
 	$(BUCK) audit rules App/BUCK > Config/Gen/App-BUCK.py


### PR DESCRIPTION
Addresses https://github.com/airbnb/BuckSample/pull/71#issuecomment-480434648

Note that `make test` executes all of our tests:
```
$ make test
tools/buck test //App:ExampleAppCITests --test-runner-env FOO=BAR
Action graph will be rebuilt because files have been added or removed.
Building: finished in 36.6 sec (100%) 242/242 jobs, 239 updated
  Total time: 37.0 sec
Testing: finished in 9.0 sec (11 PASS/0 FAIL)
RESULTS FOR //App:ExampleAppCITests //App:UnitTests //App:UnitTestsWithHostApp //App:XCUITests
PASS    <100ms  1 Passed   0 Skipped   0 Failed   ReliesOnCXXTests
PASS    <100ms  1 Passed   0 Skipped   0 Failed   SomeASwiftModuleTests
PASS    <100ms  2 Passed   0 Skipped   0 Failed   SomeMoreSecondSwiftModuleTests
PASS    <100ms  2 Passed   0 Skipped   0 Failed   SomeSecondSwiftModuleTests
PASS    <100ms  1 Passed   0 Skipped   0 Failed   SwiftWithAssetsTests
PASS     267ms  3 Passed   0 Skipped   0 Failed   BuckSampleTests
PASS    <100ms  1 Passed   0 Skipped   0 Failed   BuckSampleTests
TESTS PASSED
````