### PR TITLE
Enable code coverage for Buck build

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -41,3 +41,4 @@
   code_coverage_cxxflags = -fprofile-instr-generate -fcoverage-mapping
   code_coverage_ldflags = -fprofile-instr-generate
   code_coverage_swift_compiler_flags = -profile-generate -profile-coverage-mapping
+  

--- a/.buckconfig
+++ b/.buckconfig
@@ -1,14 +1,14 @@
 [cxx]
   default_platform = iphonesimulator-x86_64
-  cflags = -g -fmodules -fobjc-arc -D BUCK -w
-  cxxflags = -fobjc-arc -std=c++14 -D DEBUG -g
+  cflags = -g -fmodules -fobjc-arc -D BUCK -w $(config custom.other_cflags)
+  cxxflags = -fobjc-arc -std=c++14 -D DEBUG -g $(config custom.other_cxxflags)
   combined_preprocess_and_compile = true
   pch_enabled = false
-  ldflags = -Xlinker -objc_abi_version -Xlinker 2 -fobjc-arc -fobjc-link-runtime
+  ldflags = -Xlinker -objc_abi_version -Xlinker 2 -fobjc-arc -fobjc-link-runtime $(config custom.other_cxxflags)
 
 [swift]
   version = 4.0
-  compiler_flags = -DBUCK -enable-testing -g -Onone -whole-module-optimization
+  compiler_flags = -DBUCK -enable-testing -g -Onone -whole-module-optimization $(config custom.other_swift_compiler_flags)
   use_filelist = true
 
 [apple]
@@ -33,7 +33,11 @@
   ignore = tools, \
            .git, \
 
-
 [build]
   threads = 4
 
+[custom]
+  code_coverage_cflags = -fprofile-instr-generate -fcoverage-mapping
+  code_coverage_cxxflags = -fprofile-instr-generate -fcoverage-mapping
+  code_coverage_ldflags = -fprofile-instr-generate
+  code_coverage_swift_compiler_flags = -profile-generate -profile-coverage-mapping

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,18 @@ targets:
 ci: install_buck targets build test project xcode_tests watch message
 	echo "Done"
 
-test:
-	$(BUCK) test //App:ExampleAppCITests --test-runner-env FOO=BAR
+
+buck_out = $(shell $(BUCK) root)/buck-out
+test:	
+	@rm -f $(buck_out)/tmp/*.profraw
+	@rm -f $(buck_out)/gen/*.profdata
+	$(BUCK) test //App:ExampleAppCITests --test-runner-env XCTOOL_TEST_ENV_LLVM_PROFILE_FILE="$(buck_out)/tmp/code-%p.profraw%15x" \
+		--config custom.other_cflags="\$$(config custom.code_coverage_cflags)" \
+		--config custom.other_cxxflags="\$$(config custom.code_coverage_cxxflags)" \
+		--config custom.other_ldflags="\$$(config custom.code_coverage_ldflags)" \
+		--config custom.other_swift_compiler_flags="\$$(config custom.code_coverage_swift_compiler_flags)"
+	xcrun llvm-profdata merge -sparse "$(buck_out)/tmp/code-"*.profraw -o "$(buck_out)/gen/Coverage.profdata"
+	xcrun llvm-cov report "$(buck_out)/gen/App/ExampleAppBinary#iphonesimulator-x86_64" -instr-profile "$(buck_out)/gen/Coverage.profdata"
 
 audit:
 	$(BUCK) audit rules App/BUCK > Config/Gen/App-BUCK.py


### PR DESCRIPTION
This PR demonstrates code coverage with Buck CLI build.

[This article](http://clang.llvm.org/docs/SourceBasedCodeCoverage.html) explained how  to enable code coverage in detail.  Besides passing `-fprofile-instr-generate -fcoverage-mapping` to the obj-c compiler, we also need to pass `-profile-generate -profile-coverage-mapping` to the swift compiler and pass `-fprofile-instr-generate` to the linker.

The difficult part is setting environment variable LLVM_PROFILE_FILE to the simulator, where the tests are actually running. We need to do this through `buck` to `xctool`. Although `buck test` has an option `—test-runner-env`, but it doesn’t seem to be working. It turns out that `xctool` only accepts environment variable with `XCTOOL_TEST_ENV_` prefix, so it should be `—test-runner-env XCTOOL_TEST_ENV_LLVM_PROFILE_FILE=path/to/profraw`. This isn’t documented anywhere, besides [a comment](https://github.com/facebook/buck/blob/0cf9e77a4ebbadb5b17fcedfa36cfb8b2d6bcf85/src/com/facebook/buck/apple/XctoolRunTestsStep.java#L218) in buck source code.

After testing, we merge  `profraw`  files into  `Coverage.profdata` by `llvm-profdata`. Once we have `Coverage.profdata` and the app binary, we can use[`llvm-cov`](https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-report) to generate the report, show coverage in the code, etc.

_showing the report_
<img width="1901" alt="Screen Shot 2019-04-09 at 10 12 30 PM" src="https://user-images.githubusercontent.com/6559265/55916420-30e9c600-5ba1-11e9-9371-631e6c687dbe.png">

_showing uncovered area_
<img width="1516" alt="Screen Shot 2019-04-09 at 10 16 23 PM" src="https://user-images.githubusercontent.com/6559265/55916427-35ae7a00-5ba1-11e9-94f9-81a42ead13fb.png">

