### PR TITLE
Add documentation for first_party_library_dependencies

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -23,6 +23,8 @@ ui_tests = [
     ":XCUITests",
 ]
 
+# This is a list of all of our first-party libraries that are depended upon (directly or transitively) by this application.
+# Every first-party library has an associated test target. We use this list to determine what test targets to run in CI.
 first_party_library_dependencies = [
     "//Libraries/ASwiftModule:ASwiftModule",
     "//Libraries/Cpp1:Cpp1",


### PR DESCRIPTION
Title says it all. Figured this was a good thing to document.