### PR TITLE
Fix Xcode project and `make debug`

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -166,6 +166,7 @@ apple_package(
 # binary, the Copy Files phase to embed the watch app and extension will search the `iphoneos` directory,
 # and fail the build on generated Xcode projects.
 
+# This is the code that runs on the iPhone and talks to the app running on the Watch.
 apple_binary(
     name = "ExampleWatchAppExtensionBinary",
     srcs = glob([
@@ -203,6 +204,12 @@ apple_bundle(
     xcode_product_type = "com.apple.product-type.watchkit2-extension",
 )
 
+# This is the code that runs on the Watch.
+apple_binary(
+    name = "ExampleWatchAppBinary",
+    configs = watch_binary_configs("ExampleApp.WatchApp")
+)
+
 apple_bundle(
     name = "ExampleWatchApp",
     binary = ":ExampleWatchAppBinary",
@@ -223,11 +230,6 @@ apple_bundle(
         ":ExampleWatchAppExtension",
         ":ExampleWatchAppResources",
     ],
-)
-
-apple_binary(
-    name = "ExampleWatchAppBinary",
-    configs = watch_binary_configs("ExampleApp.WatchApp")
 )
 
 apple_resource(

--- a/App/WatchApplication/Info.plist
+++ b/App/WatchApplication/Info.plist
@@ -18,7 +18,7 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-		<key>CFBundleSignature</key>
+	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
 	<array>

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -87,6 +87,8 @@ def info_plist_substitutions(name):
     }
     return substitutions
 
+# TODO: Right now this is being used for both the code that runs on the Watch and the extension
+# that runs on the iPhone. I wonder if it would make sense to break this into two methods.
 def watch_binary_configs(name):
     config = {
         "SDKROOT": "watchos",
@@ -94,8 +96,10 @@ def watch_binary_configs(name):
         "TARGETED_DEVICE_FAMILY": "4",
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
         "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks",
+        "WK_COMPANION_APP_BUNDLE_IDENTIFIER": bundle_identifier("ExampleApp"),
+        "WK_APP_BUNDLE_IDENTIFIER": bundle_identifier("ExampleApp.WatchApp"),
         # Not sure why, but either adding this or removing -whole-module-optimization can make it compile
-        "SWIFT_COMPILATION_MODE": "wholemodule"
+        "SWIFT_COMPILATION_MODE": "wholemodule",
     }
     config = config_with_updated_linker_flags(config, ALL_LOAD_LINKER_FLAG)
     return configs_with_config(config)

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -87,8 +87,13 @@ def info_plist_substitutions(name):
     }
     return substitutions
 
-# TODO: Right now this is being used for both the code that runs on the Watch and the extension
-# that runs on the iPhone. I wonder if it would make sense to break this into two methods.
+# TODO: Currently this macro is used for both the watch app and the watch extension. This macro
+# should be split into two, one for each of those binaries, as the configurations are diverging.
+# At the very least only the watch extension needs the `WK_APP_BUNDLE_IDENTIFIER` key/value pair,
+# and only the watch app needs the `WK_COMPANION_APP_BUNDLE_IDENTIFIER` key value pair. I also
+# wonder if some of these other configuration settings are only necessary for one binary or the
+# other. I cannot verify any of this at the moment due to
+# https://github.com/airbnb/BuckSample/issues/97.
 def watch_binary_configs(name):
     config = {
         "SDKROOT": "watchos",

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ message:
 	$(BUCK) build //App:ExampleMessageExtension
 
 debug:
-	$(BUCK) install //App:ExampleApp --run --simulator-name 'Phone: iPhone XS'
+	$(BUCK) install //App:ExampleApp --run --simulator-name 'iPhone XS'
 
 targets:
 	$(BUCK) targets //...
@@ -35,7 +35,7 @@ ci: install_buck targets build test ui_test project xcode_tests watch message
 
 
 buck_out = $(shell $(BUCK) root)/buck-out
-test:	
+test:
 	@rm -f $(buck_out)/tmp/*.profraw
 	@rm -f $(buck_out)/gen/*.profdata
 	$(BUCK) test //App:ExampleAppCITests --test-runner-env XCTOOL_TEST_ENV_LLVM_PROFILE_FILE="$(buck_out)/tmp/code-%p.profraw%15x" \


### PR DESCRIPTION
- https://github.com/airbnb/BuckSample/pull/87 broke building and running with the Xcode project. `info_plist_substitutions` will work for Buck CLI builds, but these substitutions need to be added to `configs` for Xcode builds to work. cc: @gsabran 
- Remove `Phone :` from `make debug` command that was preventing the simulator from launching.

The app crashes on launch with `make debug`, and I've tracked that issue here: https://github.com/airbnb/BuckSample/issues/91