### PR TITLE
[Blocked on CI upgrade] Test that app installs to simulator via CLI in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ debug:
 targets:
 	$(BUCK) targets //...
 
-ci: install_buck targets build test ui_test project xcode_tests watch message
+ci: install_buck targets build test ui_test project xcode_tests watch message debug
 	echo "Done"
 
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ message:
 	$(BUCK) build //App:ExampleMessageExtension
 
 debug:
-	$(BUCK) install //App:ExampleApp --run --simulator-name 'iPhone XS'
+	$(BUCK) install //App:ExampleApp --run --simulator-name 'iPhone X'
 
 targets:
 	$(BUCK) targets //...


### PR DESCRIPTION
Fixes #93. We cannot remove "Built and ran with Buck CLI (`make debug`)" from the PR template until #94 is fixed as well. And we can't do that until we get the app to actually run via the CLI again 😬

I verified that when `make debug` times out it fails with a non-zero exit code.
