### PR TITLE
Consolidate on `en` for development language

### DIFF
--- a/App/BUCK
+++ b/App/BUCK
@@ -1,4 +1,4 @@
-load("//Config:configs.bzl", "app_binary_configs", "library_configs", "watch_binary_configs", "message_binary_configs", "pretty", "info_plist_substitutions", "bundle_identifier")
+load("//Config:configs.bzl", "app_binary_configs", "library_configs", "watch_binary_configs", "message_binary_configs", "pretty", "info_plist_substitutions", "bundle_identifier", "DEVELOPMENT_LANGUAGE")
 load("//Config:buck_rule_macros.bzl", "apple_lib", "apple_test_lib", "apple_test_all")
 
 apple_asset_catalog(
@@ -196,7 +196,7 @@ apple_bundle(
     extension = "appex",
     info_plist = "WatchExtension/Info.plist",
     info_plist_substitutions = {
-        "DEVELOPMENT_LANGUAGE": "en-us",
+        "DEVELOPMENT_LANGUAGE": DEVELOPMENT_LANGUAGE,
         "EXECUTABLE_NAME": "ExampleWatchAppExtension",
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier("ExampleApp.WatchApp.Extension"),
         "WK_APP_BUNDLE_IDENTIFIER": bundle_identifier("ExampleApp.WatchApp"),
@@ -221,7 +221,7 @@ apple_bundle(
     extension = "app",
     info_plist = "WatchApplication/Info.plist",
     info_plist_substitutions = {
-        "DEVELOPMENT_LANGUAGE": "en-us",
+        "DEVELOPMENT_LANGUAGE": DEVELOPMENT_LANGUAGE,
         "EXECUTABLE_NAME": "ExampleWatchApp",
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier("ExampleApp.WatchApp"),
         "WK_COMPANION_APP_BUNDLE_IDENTIFIER": bundle_identifier("ExampleApp"),
@@ -275,7 +275,7 @@ apple_bundle(
     extension = "appex",
     info_plist = "MessageExtension/Info.plist",
     info_plist_substitutions = {
-        "DEVELOPMENT_LANGUAGE": "en-us",
+        "DEVELOPMENT_LANGUAGE": DEVELOPMENT_LANGUAGE,
         "EXECUTABLE_NAME": "ExampleMessageExtension",
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier("ExampleApp.MessageExtension"),
         "PRODUCT_NAME": "ExampleMessageExtension",

--- a/Config/buck_rule_macros.bzl
+++ b/Config/buck_rule_macros.bzl
@@ -1,4 +1,4 @@
-load("//Config:configs.bzl", "test_configs", "library_configs", "pod_library_configs")
+load("//Config:configs.bzl", "test_configs", "library_configs", "pod_library_configs", "DEVELOPMENT_LANGUAGE")
 
 # This is just a regular lib that was warnings not set to error
 def apple_third_party_lib(**kwargs):
@@ -53,7 +53,7 @@ def apple_test_lib(
 
     substitutions = {
         "CURRENT_PROJECT_VERSION": "1",
-        "DEVELOPMENT_LANGUAGE": "en-us",
+        "DEVELOPMENT_LANGUAGE": DEVELOPMENT_LANGUAGE,
         "EXECUTABLE_NAME": name,
         "PRODUCT_BUNDLE_IDENTIFIER": "com.airbnb.%s" % name,
         "PRODUCT_NAME": name,
@@ -198,13 +198,13 @@ def first_party_library(
         suppress_warnings = suppress_warnings,
         **kwargs
     )
-    
+
     test_sources = native.glob(["Tests/**/*.swift"])
     test_headers = None
     if has_objective_c:
         test_sources.extend(native.glob(["Tests/**/*.m"]))
         test_headers = native.glob(["Tests/**/*.h"])
-    
+
     apple_test_lib(
         name = lib_test_name,
         srcs = test_sources,

--- a/Config/configs.bzl
+++ b/Config/configs.bzl
@@ -1,5 +1,7 @@
 load("//Config:utils.bzl", "config_with_updated_linker_flags", "configs_with_config")
 
+DEVELOPMENT_LANGUAGE = "en"
+
 def pretty(dict, current = ""):
     current = "\n"
     indent = 0
@@ -53,7 +55,7 @@ def library_configs():
 def app_binary_configs(name):
     binary_specific_config = {
         "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
-        "DEVELOPMENT_LANGUAGE": "Swift",
+        "DEVELOPMENT_LANGUAGE": DEVELOPMENT_LANGUAGE,
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
     }
     binary_config = SHARED_CONFIGS + binary_specific_config
@@ -80,7 +82,7 @@ def pod_library_configs():
 
 def info_plist_substitutions(name):
     substitutions = {
-        "DEVELOPMENT_LANGUAGE": "en-us",
+        "DEVELOPMENT_LANGUAGE": DEVELOPMENT_LANGUAGE,
         "EXECUTABLE_NAME": name,
         "PRODUCT_BUNDLE_IDENTIFIER": bundle_identifier(name),
         "PRODUCT_NAME": name,

--- a/Config/utils.bzl
+++ b/Config/utils.bzl
@@ -9,7 +9,7 @@ OTHER_LINKER_FLAGS_KEY = 'OTHER_LDFLAGS'
 #
 # {
 #   "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
-#   "DEVELOPMENT_LANGUAGE": "Swift",
+#   "DEVELOPMENT_LANGUAGE": "en",
 #   /* ... */
 # }
 #
@@ -19,12 +19,12 @@ OTHER_LINKER_FLAGS_KEY = 'OTHER_LDFLAGS'
 # {
 #   "Debug": {
 #     "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
-#     "DEVELOPMENT_LANGUAGE": "Swift",
+#     "DEVELOPMENT_LANGUAGE": "en",
 #     /* ... */
 #   },
 #   "Release": {
 #     "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES": "YES",
-#     "DEVELOPMENT_LANGUAGE": "Swift",
+#     "DEVELOPMENT_LANGUAGE": "en",
 #     /* ... */
 #   }
 # }


### PR DESCRIPTION
I believe this is the root cause problem of https://github.com/airbnb/BuckSample/issues/101.

Right now we are setting this to `en-us` in some places and `Swift` in other 🤦‍♂ 

In a standard Xcode project, this defaults to `en`. Apple suggested I set it to `en`.

In our production app, we are inconsistent. In one target we have it as `English` (which is invalid). In two others I checked we have it as `en`.

It feels inelegant setting a global variable, but this also feels like a step in the right direction of being more DRY.

Thank you Apple for your help, if you're watching 😄 

I'm leaving that issue open until I rebase my other branch.

- [x] Built and ran in Xcode (`make project`)
- [x] Built and ran with Buck CLI (`make debug`)

cc: @qyang-nj @dfed 
