### PR TITLE
WIP - buck caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ jobs:
       TERM: dumb
     steps:
       - checkout
-      
       - restore_cache:
           name: Restore Buck build cache
           keys: 
@@ -21,15 +20,22 @@ jobs:
       - run:
           name: Build and run tests
           command: make ci
+      
+      - save_cache:
+          name: Cache Buck build cache
+          key: buck-build-cache-beta # FIXME: make this v1 before merging
+          when: always
+          paths: 
+            - buck-out/cache
 
-      - when:
-          condition: [ $CIRCLE_BRANCH = 'master' ] # FIXME: make this master before merging
-          steps:
-            - save_cache:
-                name: Cache Buck build cache
-                key: buck-build-cache-beta # FIXME: make this v1 before merging
-                paths: 
-                  - buck-out/cache
+      # - when:
+      #     condition: [ $CIRCLE_BRANCH = 'master' ] # FIXME: make this master before merging
+      #     steps:
+      #       - save_cache:
+      #           name: Cache Buck build cache
+      #           key: buck-build-cache-beta # FIXME: make this v1 before merging
+      #           paths: 
+      #             - buck-out/cache
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   build-and-test:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,10 @@ jobs:
       TERM: dumb
     steps:
       - checkout
+      - restore_cache:
+          name: Restore Buck build cache
+          keys: 
+            - buck-build-cache-beta # FIXME: make this v1 before merging
       - run:
           name: Prepare environment
           command: |
@@ -16,6 +20,14 @@ jobs:
       - run:
           name: Build and run tests
           command: make ci
+
+      - when:
+          condition: [ $CIRCLE_BRANCH = 'master-build-cache' ] # FIXME: make this master before merging
+          - save_cache:
+              name: Cache Buck build cache
+              key: buck-build-cache-beta # FIXME: make this v1 before merging
+              paths: 
+                - buck-out/cache
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,13 @@ jobs:
           command: make ci
 
       - when:
-          condition: [ $CIRCLE_BRANCH = 'master-build-cache' ] # FIXME: make this master before merging
-          - save_cache:
-              name: Cache Buck build cache
-              key: buck-build-cache-beta # FIXME: make this v1 before merging
-              paths: 
-                - buck-out/cache
+          condition: [ $CIRCLE_BRANCH = 'master' ] # FIXME: make this master before merging
+          steps:
+            - save_cache:
+                name: Cache Buck build cache
+                key: buck-build-cache-beta # FIXME: make this v1 before merging
+                paths: 
+                  - buck-out/cache
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       TERM: dumb
     steps:
       - checkout
+      
       - restore_cache:
           name: Restore Buck build cache
           keys: 


### PR DESCRIPTION
- [ ] Built and ran in Xcode (`make project`)
- [ ] Built and ran with Buck CLI (`make debug`)


Need to figure out what the CIRCLE_BRANCH_NAME variable is on forks to test this... but structure I think would be something like this.

There's a cleaner way to do this in configs as well where you extract things into `commands` that you use as building blocks for `jobs` and then orchestrate them differently on branches, but this is a start
