### PR TITLE
Initialize window in the example app's AppDelegate correctly

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -8,14 +8,15 @@ typealias ArgType = [UIApplicationLaunchOptionsKey : Any]? // Xcode 9
 #endif
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+final class AppDelegate: UIResponder, UIApplicationDelegate {
 
-  let window = UIWindow(frame: UIScreen.main.bounds)
+  private var window: UIWindow?
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: ArgType) -> Bool {
   
-    window.makeKeyAndVisible()
-    window.rootViewController = ViewController()
+    window = UIWindow(frame: UIScreen.main.bounds)
+    window?.makeKeyAndVisible()
+    window?.rootViewController = ViewController()
 
     return true
   }


### PR DESCRIPTION
👋 Greetings!

First of all, great work to everyone who contributed thus far. As a iOS dev new to Buck, this repo has been immensely helpful in learning the best practices.

One thing I noticed is that occasionally when running the example application, the sim will go black and the following is output is visible in the console:

```
ExampleApp[14655:2132796] [ApplicationLifecycle] UIWindows were created prior to initial application activation. This may result in incorrect visual appearance.
```

As far as I know, this is a simple change to initialize the window once the appropriate life cycle method is called on the app delegate. Immutable initialization as an instance property cannot ensure that the window is initialized at the right time.