### PR TITLE
Add graph generation to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ vendor/bundle/
 
 # Build
 build/
+
+# DAG chart generated
+result.dot
+result.png

--- a/Makefile
+++ b/Makefile
@@ -95,5 +95,5 @@ project: clean
 buck_local_project: clean
 	bundle exec rake buck_local:generate_project buck_binary_path=$(BUCK) workspace_target='//App:workspace-buck-local' top_level_lib_target='//App:ExampleAppLibrary' xcworkspace='App/ExampleAppBuckLocal.xcworkspace'
 	open App/ExampleAppBuckLocal.xcworkspace
-graph:
+dependency_graph:
 	$(BUCK) query "deps(//App:ExampleAppBinary)" --dot > result.dot &&  dot result.dot -Tpng -o result.png && open result.png

--- a/Makefile
+++ b/Makefile
@@ -95,3 +95,5 @@ project: clean
 buck_local_project: clean
 	bundle exec rake buck_local:generate_project buck_binary_path=$(BUCK) workspace_target='//App:workspace-buck-local' top_level_lib_target='//App:ExampleAppLibrary' xcworkspace='App/ExampleAppBuckLocal.xcworkspace'
 	open App/ExampleAppBuckLocal.xcworkspace
+graph:
+	$(BUCK) query "deps(//App:ExampleAppBinary)" --dot > result.dot &&  dot result.dot -Tpng -o result.png && open result.png


### PR DESCRIPTION
One great use case for this repo is to prototype your project's dependency DAG with Buck. Instead of generating a project, I found it was much easier to arrange frameworks by generating a chart to reflect the current Buck DAG. 

I'm not sure if others will find it helpful, but I did as I worked to migrate our ~25 internal and ~35 external framework project into the Buck build system.

![make_dag](https://user-images.githubusercontent.com/7704414/101266834-fc306800-370f-11eb-949f-cc8ac090bb53.gif)


